### PR TITLE
preserve user's PROMPT_COMMAND variable in iterm2 shell integration

### DIFF
--- a/source/misc/bash_startup.in
+++ b/source/misc/bash_startup.in
@@ -134,7 +134,7 @@ function preexec_install () {
     shopt -s extdebug > /dev/null 2>&1
 
     # Finally, install the actual traps.
-    PROMPT_COMMAND="preexec_invoke_cmd";
+    PROMPT_COMMAND="preexec_invoke_cmd${PROMPT_COMMAND}";
     trap 'preexec_invoke_exec' DEBUG;
 }
 


### PR DESCRIPTION
This preserves PROMPT_COMMAND that could be previously set by user in another script f.e.: .bash_profile
I use this fix without any issues on many nodes.
