### PR TITLE
zsh shell integration fixes

### DIFF
--- a/source/misc/zsh_startup.in
+++ b/source/misc/zsh_startup.in
@@ -3,36 +3,46 @@ ST_NAME=`hostname -f`
 echo Here we go
 [ x"$TERM" = "xscreen" ] && exit
 
-# iTerm2 inform terminal that command starts here
+_iterm_ft_cmd () {
+    printf $'\e]133;%s\x07' $@
+}
+_iterm_si_cmd () {
+    printf $'\e]1337;%s=%s\x07' $@
+}
+
+# iTerm2 inform terminal that command ends & output starts here
 before_cmd_executes() {
-  printf "\033]133;D;$?\007\033]1337;RemoteHost='$USER'@`hostname -f`\007\033]1337;CurrentDir=$PWD\007"
+    _iterm_ft_cmd 'C'
 }
 
-# iTerm2 tell terminal to create a mark at this location
 after_cmd_executes() {
-  printf "\033]133;C\007"
+    _iterm_ft_cmd "D;$?" # return value of previous command
+    _iterm_si_cmd "RemoteHost" "'$USER'@$(hostname -f)"
+    _iterm_si_cmd "CurrentDir" "$PWD"
 }
 
-# iTerm2 mark start of prompt
+after_pwd_changes() {
+    _iterm_si_cmd "CurrentDir" "$PWD"
+}
+
+# iTerm2 mark start of prompt / end of previous output.
+# Command marker in gutter will be inserted here.
 iterm_prompt_start() {
-  print -Pn "\033]133;A\007"
+    _iterm_ft_cmd "A"
 }
 
-# iTerm2 mark end of prompt
+# iTerm2 mark end of prompt / start of command input.
 iterm_prompt_end() {
-  print -Pn "\033]133;B\007"
+    _iterm_ft_cmd "B"
 }
 
-PS1="%{$(iterm_prompt_start)%}$PS1%{$(iterm_prompt_end)%}"
+PROMPT="%{$(iterm_prompt_start)%}$PROMPT%{$(iterm_prompt_end)%}"
 
-precmd() {
-  after_cmd_executes
-}
+autoload -Uz add-zsh-hook
+add-zsh-hook preexec before_cmd_executes
+add-zsh-hook precmd after_cmd_executes
+add-zsh-hook chpwd after_pwd_changes
 
-preexec() {
-  before_cmd_executes
-}
-
-printf "\033]1337;RemoteHost='$USER'@`hostname -f`\007"
-printf "\033]1337;CurrentDir=$PWD\007"
-printf "\033]1337;ShellIntegrationVersion=1\007"
+_iterm_si_cmd "RemoteHost" "'$USER'@$(hostname -f)"
+_iterm_si_cmd "CurrentDir" "$PWD"
+_iterm_si_cmd "ShellIntegrationVersion" "1"


### PR DESCRIPTION
Issue escapes in right order to make shell integration (last cmd output and cmd returnvalue) work, assuming a single-line prompt.

Refactored to make things a bit more zsh-idiomatic, like using hooks rather than overwriting preexec/cmd so it plays well with other plugins.
