### PR TITLE
Fix Shell Integration: Issue with piped sub-shells

### DIFF
--- a/source/misc/bash_startup.in
+++ b/source/misc/bash_startup.in
@@ -94,6 +94,13 @@ if ( [ x"$TERM" != xscreen ] ); then
   # environment to attempt to detect if the current command is being invoked
   # interactively, and invoke 'preexec' if so.
   function preexec_invoke_exec () {
+      if [ ! -t 1 ]
+      then
+          # We're in a piped subshell (STDOUT is not a TTY) like
+          #   (echo -n A; sleep 1; echo -n B) | wc -c
+          # ...which should return "2".
+          return
+      fi
       if [[ -n "$COMP_LINE" ]]
       then
           # We're in the middle of a completer.  This obviously can't be


### PR DESCRIPTION
Fixes iTerm2-Issue #3526 "iTerm2 Shell Integrations affect STDOUT of piped sub-shells"

Issue: https://gitlab.com/gnachman/iterm2/issues/3526

without this fix consider the following test:
``` bash
true | wc -c             # outputs: 0
(true) | wc -c           # outputs: 8
(true) | true | wc -c    # outputs: 0
(true) | (true) | wc -c  # outputs: 8
(true | true) | wc -c    # outputs: 16
```