### PR TITLE
Use fish 2.2 fish_preexec, fish_postexec, and fish_prompt hooks...

### DIFF
--- a/source/misc/fish_startup.in
+++ b/source/misc/fish_startup.in
@@ -1,71 +1,70 @@
-if [ x"$TERM" != "xscreen" ] 
-  function iterm2_status
-    printf "\033]133;D;%s\007" $argv
-  end
+set -l fishversion (echo $FISH_VERSION | sed 's|\(.\)\.\(.\).*|\1\2|')
+if [ $fishversion -ge 22 ]
+  if [ x"$TERM" != "xscreen" ]
 
-  # Mark start of prompt
-  function iterm2_prompt_start
-    printf "\033]133;A\007"
-  end
-
-  # Mark end of prompt
-  function iterm2_prompt_end
-    printf "\033]133;B\007"
-  end
-
-  # Tell terminal to create a mark at this location
-  function iterm2_preexec
-    # For other shells we would output status here but we can't do that in fish.
-    printf "\033]133;C\007"
-  end
-
-  # Usage: iterm2_set_user_var key value
-  # These variables show up in badges (and later in other places). For example
-  # iterm2_set_user_var currentDirectory "$PWD"
-  # Gives a variable accessible in a badge by \(user.currentDirectory)
-  # Calls to this go in iterm2_print_user_vars.
-  function iterm2_set_user_var
-    printf "\033]1337;SetUserVar=%s=%s\007" "$argv[1]" (printf "%s" "$argv[2]" | base64)
-  end
-
-  # Users can override this.
-  # It should call iterm2_set_user_var and produce no other output.
-  function iterm2_print_user_vars
-  end
-
-  # iTerm2 inform terminal that command starts here
-  function iterm2_precmd
-    printf "\033]1337;RemoteHost=%s@%s\007\033]1337;CurrentDir=$PWD\007" $USER $iterm2_hostname
-    iterm2_print_user_vars
-  end
-
-  functions -c fish_prompt iterm2_fish_prompt
-
-  function fish_prompt --description 'Write out the prompt; do not replace this. Instead, change fish_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_prompt instead.'
-    # Save our status
-    set -l last_status $status
-
-    iterm2_status $last_status
-    iterm2_prompt_start
-    # Restore the status
-    sh -c "exit $last_status"
-    iterm2_fish_prompt
-    iterm2_prompt_end
-  end
-
-  function -v _ underscore_change
-    if [ x$_ = xfish ]
-      iterm2_precmd
-    else
-      iterm2_preexec
+    function iterm2_status -e fish_postexec
+      printf "\033]133;D;%s\007" $status
     end
-  end
 
-  # If hostname -f is slow for you, set iterm2_hostname before sourcing this script
-  if not set -q iterm2_hostname
-    set iterm2_hostname (hostname -f)
-  end
+    # Mark start of prompt
+    function iterm2_prompt_start
+      printf "\033]133;A\007"
+    end
 
-  iterm2_precmd
-  printf "\033]1337;ShellIntegrationVersion=1\007"
+    # Mark end of prompt
+    function iterm2_prompt_end
+      printf "\033]133;B\007"
+    end
+
+    # Tell terminal to create a mark at this location
+    function iterm2_preexec -e fish_preexec
+      printf "\033]133;C\007"
+    end
+
+    # Usage: iterm2_set_user_var key value
+    # These variables show up in badges (and later in other places). For example
+    # iterm2_set_user_var currentDirectory "$PWD"
+    # Gives a variable accessible in a badge by \(user.currentDirectory)
+    # Calls to this go in iterm2_print_user_vars.
+    function iterm2_set_user_var
+      printf "\033]1337;SetUserVar=%s=%s\007" "$argv[1]" (printf "%s" "$argv[2]" | base64)
+    end
+
+    # Users can override this.
+    # It should call iterm2_set_user_var and produce no other output.
+    function iterm2_print_user_vars
+    end
+
+    # iTerm2 inform terminal that command starts here
+    function iterm2_precmd -e fish_postexec
+      printf "\033]1337;RemoteHost=%s@%s\007\033]1337;CurrentDir=$PWD\007" $USER $iterm2_hostname
+      iterm2_print_user_vars
+    end
+
+    function iterm2_prompt -e fish_prompt
+      functions -e iterm2_fish_prompt
+      functions -c fish_prompt iterm2_fish_prompt
+      function fish_prompt
+        set -l last_status $status
+        iterm2_prompt_start
+        # Restore the status
+        sh -c "exit $last_status"
+        iterm2_fish_prompt
+        iterm2_prompt_end
+      end
+    end
+
+    function restore_prompt -e fish_preexec
+      funced -e cat iterm2_fish_prompt | sed 's|iterm2_fish_prompt|fish_prompt|' | source
+      functions -e iterm2_fish_prompt
+    end
+
+    # If hostname -f is slow for you set iterm2_hostname before sourcing this script
+    if not set -q iterm2_hostname
+      set iterm2_hostname (hostname -f)
+    end
+
+    iterm2_precmd
+    printf "\033]1337;ShellIntegrationVersion=1\007"
+  end
 end


### PR DESCRIPTION
Fish 2.2 is to be [released imminently](https://github.com/fish-shell/fish-shell/releases/tag/2.2.0) and has all the nice hooks needed. I've also used these hooks so that the change to `fish_prompt` is transparent to the user.