### PR TITLE
For shell equality tests, use '=' instead of '=='

### DIFF
--- a/source/misc/install_shell_integration.sh
+++ b/source/misc/install_shell_integration.sh
@@ -12,25 +12,25 @@ URL=""
 HOME_PREFIX='${HOME}'
 SHELL_AND='&&'
 QUOTE=''
-if [ "${SHELL}" == tcsh ]
+if [ "${SHELL}" = tcsh ]
 then
   URL="https://iterm2.com/misc/tcsh_startup.in"
   SCRIPT="${HOME}/.login"
   QUOTE='"'
 fi
-if [ "${SHELL}" == zsh ]
+if [ "${SHELL}" = zsh ]
 then
   URL="https://iterm2.com/misc/zsh_startup.in"
   SCRIPT="${HOME}/.zshrc"
   QUOTE='"'
 fi
-if [ "${SHELL}" == bash ]
+if [ "${SHELL}" = bash ]
 then
   URL="https://iterm2.com/misc/bash_startup.in"
   test -f "${HOME}/.bash_profile" && SCRIPT="${HOME}/.bash_profile" || SCRIPT="${HOME}/.profile"
   QUOTE='"'
 fi
-if [ "${SHELL}" == fish ]
+if [ "${SHELL}" = fish ]
 then
   echo "Make sure you have fish 2.2 or later. Your version is:"
   fish -v
@@ -41,7 +41,7 @@ then
   HOME_PREFIX='{$HOME}'
   SHELL_AND='; and'
 fi
-if [ "${URL}" == "" ]
+if [ "${URL}" = "" ]
 then
   die "Your shell, ${SHELL}, is not supported yet. Only tcsh, zsh, bash, and fish are supported. Sorry!"
   exit 1

--- a/source/misc/install_shell_integration_and_utilities.sh
+++ b/source/misc/install_shell_integration_and_utilities.sh
@@ -12,28 +12,28 @@ URL=""
 HOME_PREFIX='${HOME}'
 SHELL_AND='&&'
 QUOTE=''
-if [ "${SHELL}" == tcsh ]
+if [ "${SHELL}" = tcsh ]
 then
   URL="https://iterm2.com/misc/tcsh_startup.in"
   SCRIPT="${HOME}/.login"
   QUOTE='"'
   ALIASES='alias imgcat ~/.iterm2/imgcat; alias it2dl ~/.iterm2/it2dl'
 fi
-if [ "${SHELL}" == zsh ]
+if [ "${SHELL}" = zsh ]
 then
   URL="https://iterm2.com/misc/zsh_startup.in"
   SCRIPT="${HOME}/.zshrc"
   QUOTE='"'
   ALIASES='alias imgcat=~/.iterm2/imgcat; alias it2dl=~/.iterm2/it2dl'
 fi
-if [ "${SHELL}" == bash ]
+if [ "${SHELL}" = bash ]
 then
   URL="https://iterm2.com/misc/bash_startup.in"
   test -f "${HOME}/.bash_profile" && SCRIPT="${HOME}/.bash_profile" || SCRIPT="${HOME}/.profile"
   QUOTE='"'
   ALIASES='alias imgcat=~/.iterm2/imgcat; alias it2dl=~/.iterm2/it2dl'
 fi
-if [ "${SHELL}" == fish ]
+if [ "${SHELL}" = fish ]
 then
   echo "Make sure you have fish 2.2 or later. Your version is:"
   fish -v
@@ -45,7 +45,7 @@ then
   SHELL_AND='; and'
   ALIASES='alias imgcat=~/.iterm2/imgcat; alias it2dl=~/.iterm2/it2dl'
 fi
-if [ "${URL}" == "" ]
+if [ "${URL}" = "" ]
 then
   die "Your shell, ${SHELL}, is not supported yet. Only tcsh, zsh, bash, and fish are supported. Sorry!"
   exit 1


### PR DESCRIPTION
Using '==' is a bashism, so running install_shell_integration.sh or install_shell_integration_and_utilities.sh with zsh gives a rather confusing error message:

    % zsh ./install_shell_integration_and_utilities.sh
    ./install_shell_integration_and_utilities.sh:15: = not found

Using a single '=' to test for equality is more portable, so use that instead.