### PR TITLE
Only run fish shell integration in iTerm.app

### DIFF
--- a/source/misc/fish_startup.in
+++ b/source/misc/fish_startup.in
@@ -1,4 +1,4 @@
-if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ "$TERM" != screen ]; end
+if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ "$TERM_PROGRAM" = iTerm.app ]; end
   function iterm2_status
     printf "\033]133;D;%s\007" $argv
   end


### PR DESCRIPTION
The shell integration might mess up other terms, for example:
https://github.com/fish-shell/fish-shell/issues/107

This changes the `$TERM` blacklist into an iTerm-only whitelist. Idea from here:
https://superuser.com/questions/1072721/fish-terminal-iterm-only-run-shell-integration-if-terminal-is-iterm