### PR TITLE
Update fish_startup.in to move "-v" option

### DIFF
--- a/source/misc/fish_startup.in
+++ b/source/misc/fish_startup.in
@@ -83,7 +83,7 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ 
     end
   end
 
-  function -v _ underscore_change
+  function underscore_change -v _
     if [ x$_ = xfish ]
       iterm2_precmd
     else


### PR DESCRIPTION
Fish shell >=2.4.0 requires that function options be specified after the function name.