### PR TITLE
Fixing some typos and missing links in documentation

### DIFF
--- a/source/_includes/documentation-general-usage.md
+++ b/source/_includes/documentation-general-usage.md
@@ -6,7 +6,7 @@ Tabs in iTerm2 behave like tabs in other programs, most notably web browsers lik
 
 By default, the label of each tab is the name of the job that's running in that session. Some systems are configured to augment this with additional information such as the hostname you're logged in to or your current directory (this is done by sending a special code of ESC]0;string ^G).
 
-Tab labels have indicators that tell you their status. A blue dot means new input was received. An activity indicator means new out is being received. When the session ends, a  ⃠ icon appears in the tab. You can customize these indicatorsc in Preferences > Appearance.
+Tab labels have indicators that tell you their status. A blue dot means new input was received. An activity indicator means new out is being received. When the session ends, a  ⃠ icon appears in the tab. You can customize these indicators in Preferences > Appearance.
 
 #### Edit Current Session
 The *Edit Current Session* panel lets you modify the appearance of a single session. If you customize some attribute of the session (for example, by changing the default text color) then subsequent changes to that same attribute in the profile will not affect the customized session. However, changes to other attributes of the profile will affect the customized session.

--- a/source/_includes/documentation-menu-items.md
+++ b/source/_includes/documentation-menu-items.md
@@ -40,7 +40,7 @@ After a session ends (e.g., because the shell exits) this menu item becomes enab
 These options allow you to send keyboard input to more than one session. Be careful.
 
 #### Shell > Run/Stop Coprocess
-Allows you to start and stop a coprocess linked to the current session. Learn more about coprocesses.
+Allows you to start and stop a coprocess linked to the current session. <a href="/documentation-coprocesses.html">Learn more about coprocesses</a>.
 
 #### Shell > tmux > ...
 These commands let you interact with the tmux integration. The tmux dashboard is a view that lets you see all your tmux sessions and windows at a glance, adjust which are visible, rename them, and change the current tmux session.
@@ -165,7 +165,7 @@ If you have scripts located in `$HOME/Library/Application Support/iTerm/Scripts`
 ### Toolbelt Menu
 
 #### Tolbelt > Captured Output
-This toggles the visibilty of the Captured Output tool. It shows captured output located with the Capture Output trigger. See <a href="captured_output.html">Captured Output</a> fo r more information.
+This toggles the visibilty of the Captured Output tool. It shows captured output located with the Capture Output trigger. See <a href="captured_output.html">Captured Output</a> for more information.
 
 #### Toolbelt > Command History
 This toggles the visibility of the Command History tool. It shows recently used commands. You must install <a href="shell_integration.html">Shell Integration</a> for this to know your command history.

--- a/source/_includes/documentation-preferences.md
+++ b/source/_includes/documentation-preferences.md
@@ -2,7 +2,7 @@
 ### General
 <hr>
 #### Startup
-The first dropdown box lets you select how windows will be opened when iTerm2 is launched. Most users will want *Use Systme Window Restoration Setting* as it works best with <a href="restoration.html">Session Restoration</a>. Users who exclusively use the Hotkey Window may prefer *Don't Open Any Windows*. If you have a default window arrangement saved then *Open Default Window Arrangement* will be available.
+The first dropdown box lets you select how windows will be opened when iTerm2 is launched. Most users will want *Use System Window Restoration Setting* as it works best with <a href="restoration.html">Session Restoration</a>. Users who exclusively use the Hotkey Window may prefer *Don't Open Any Windows*. If you have a default window arrangement saved then *Open Default Window Arrangement* will be available.
 
 #### Open profiles window
 If selected, the Profiles Window will automatically open when iTerm2 is started.
@@ -235,7 +235,7 @@ Use HFS+ normalization instead of NFC. This helps preserve the fullwidth attribu
 This sets the transparency of the window background. It can be temporarily disabled with View > Use Transparency.
 
 #### Keep background colors opaque
-If selected, non-default background colors wil be opaque.
+If selected, non-default background colors will be opaque.
 
 #### Blur
 If selected, the window background is blurred provided the background has some transparency. Selecting a large radius will blur the background more, but (especially on Retina displays) comes with a performance penalty.


### PR DESCRIPTION
Just found a couple little pecadillos as I was reading the docs. There may be a few more, but these were the ones that jumped out at me. 