### PR TITLE
Fix hostname error for *BSD flavors

### DIFF
--- a/source/misc/bash_startup.in
+++ b/source/misc/bash_startup.in
@@ -291,7 +291,11 @@ if [[ "$TERM" != screen && "$ITERM_SHELL_INTEGRATION_INSTALLED" = "" && "$-" == 
 
   # If hostname -f is slow on your system, set iterm2_hostname before sourcing this script.
   if [ -z "${iterm2_hostname:-}" ]; then
-    iterm2_hostname=$(hostname -f)
+    iterm2_hostname=$(hostname -f 2>/dev/null)
+    # some flavors of BSD (i.e. NetBSD and OpenBSD) don't have the -f option
+    if [ $? -ne 0 ]; then
+      iterm2_hostname=$(hostname)
+    fi
   fi
   iterm2_preexec_install
 

--- a/source/misc/fish_startup.in
+++ b/source/misc/fish_startup.in
@@ -93,7 +93,11 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ 
 
   # If hostname -f is slow for you, set iterm2_hostname before sourcing this script
   if not set -q iterm2_hostname
-    set iterm2_hostname (hostname -f)
+    set iterm2_hostname (hostname -f 2>/dev/null)
+    # some flavors of BSD (i.e. NetBSD and OpenBSD) don't have the -f option
+    if test $status -ne 0
+      set iterm2_hostname (hostname)
+    end
   end
 
   iterm2_precmd

--- a/source/misc/tcsh_startup.in
+++ b/source/misc/tcsh_startup.in
@@ -11,7 +11,7 @@ if ( ! ($?iterm2_shell_integration_installed)) then
 
       # If hostname -f is slow to run on your system, set iterm2_hostname before sourcing this script.
       if ( ! ($?iterm2_hostname)) then
-          set iterm2_hostname=`hostname -f 2>/dev/null`
+          set iterm2_hostname=`hostname -f |& cat || false`
           # some flavors of BSD (i.e. NetBSD and OpenBSD) don't have the -f option
           if ( $status != 0 ) then
               set iterm2_hostname=`hostname`

--- a/source/misc/tcsh_startup.in
+++ b/source/misc/tcsh_startup.in
@@ -11,7 +11,11 @@ if ( ! ($?iterm2_shell_integration_installed)) then
 
       # If hostname -f is slow to run on your system, set iterm2_hostname before sourcing this script.
       if ( ! ($?iterm2_hostname)) then
-          set iterm2_hostname=`hostname -f`
+          set iterm2_hostname=`hostname -f 2>/dev/null`
+          # some flavors of BSD (i.e. NetBSD and OpenBSD) don't have the -f option
+          if ( $status != 0 ) then
+              set iterm2_hostname=`hostname`
+          endif
       endif
 
       set iterm2_shell_integration_installed="yes"

--- a/source/misc/zsh_startup.in
+++ b/source/misc/zsh_startup.in
@@ -120,7 +120,11 @@ if [[ -o interactive ]]; then
     }
 
     # If hostname -f is slow on your system, set iterm2_hostname prior to sourcing this script.
-    [[ -z "$iterm2_hostname" ]] && iterm2_hostname=`hostname -f`
+    [[ -z "$iterm2_hostname" ]] && iterm2_hostname=`hostname -f 2>/dev/null`
+    # some flavors of BSD (i.e. NetBSD and OpenBSD) don't have the -f option
+    if [ $? -ne 0 ]; then
+      iterm2_hostname=`hostname`
+    fi
 
     [[ -z $precmd_functions ]] && precmd_functions=()
     precmd_functions=($precmd_functions iterm2_precmd)


### PR DESCRIPTION
OpenBSD and NetBSD don’t have the -f option to the hostname command. Check if the command completed successfully, if not, then set iterm2_hostname to the output of the hostname command with no command line options.

Resolves #41.