### PR TITLE
add a function for imgcat + url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _site
 .bundle
 .idea
 source/downloads.md
+source/utilities/image_collection

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ _site
 .bundle
 .idea
 source/downloads.md
-source/utilities/image_collection

--- a/source/utilities/imgcat
+++ b/source/utilities/imgcat
@@ -62,6 +62,21 @@ function show_help() {
     echo "   or: cat filename | imgcat" 1>& 2
 }
 
+# create image directory under the directory of imgcat
+function img_folder() {
+	dir_name="$(echo ~)/.iterm2/image_collection"
+	if [ ! -d dir_name ]; then
+	    mkdir -p $dir_name
+	fi
+}
+
+# create a list to check if the picture has been downloaded
+function make_list() {
+	if [ ! -f $dir_name/list.txt ]; then
+		touch $dir_name/list.txt
+	fi
+}
+
 ## Main
 
 if [ -t 0 ]; then
@@ -95,7 +110,29 @@ while [ $# -gt 0 ]; do
         if [ -r "$1" ] ; then
             has_stdin=f
             print_image "$1" 1 "$(base64 < "$1")" "$print_filename"
-        else
+        elif curl --output /dev/null --silent --head --fail "$1"; then # check if the url is downloadable
+			img_folder
+			make_list
+			# check if already downloaded from the url
+			if grep -q $1 $dir_name/list.txt; then 
+				# get file name from the list
+				md5_name=$(echo "$(grep $1 $dir_name/list.txt)" | sed 's/.* \([0-9a-f]\)/\1/')
+			else
+				# download file with temporal name called tmp
+				curl $1 -o "$dir_name/tmp" > /dev/null 2>&1
+
+				# rename tmp to its md5 value
+				md5_name=$(echo "$(md5 $dir_name/tmp)" | sed 's/MD5 (.*) = \([0-9a-f]\)/\1/')
+				mv "$dir_name/tmp" "$dir_name/$md5_name"
+
+				# add new download file into the list
+				echo "$1 $md5_name" >> $dir_name/list.txt
+			fi
+			# reset argument of url to the corresponding md5_name
+			set -- "$dir_name/$md5_name"
+            has_stdin=f
+            print_image "$1" 1 "$(base64 < "$1")" "$print_filename"
+		else	
             error "imgcat: $1: No such file or directory"
             exit 2
         fi
@@ -108,5 +145,6 @@ done
 if [ $has_stdin = t ]; then
     print_image "" 1 "$(cat | base64)" ""
 fi
+
 
 exit 0

--- a/source/utilities/imgcat
+++ b/source/utilities/imgcat
@@ -24,7 +24,7 @@ function print_st() {
 #   filename: Filename to convey to client
 #   inline: 0 or 1
 #   base64contents: Base64-encoded contents
-#   print_filename: If non-empty, print the filename 
+#   print_filename: If non-empty, print the filename
 #                   before outputting the image
 function print_image() {
     print_osc
@@ -89,14 +89,14 @@ while [ $# -gt 0 ]; do
 	-u|--u|--url)
         if curl --output /dev/null --silent --head --fail "$2"; then # check if the url is downloadable
 			# create a file with unique file name
-			file=$(mktemp -t curlimg) || { echo "Failed creating file"; return; }
+			file=$(mktemp -t curlimg) || { echo "mktemp failed for url $2"; exit 1; }
 			# download file and save it into the unique file name just created
-    		curl -s "$2" > $file || { echo "Failed to curl file"; return; }
+    		curl -s "$2" > $file || { echo "curl failed for url $2"; exit 1; }
 			# reset argument of url to the corresponding unique file
             has_stdin=f
             print_image "$file" 1 "$(base64 < "$file")" "$print_filename"
 			# delete the downloaded file
-			rm $file
+			rm "$file"
 			# only modify second argument in order to keep running option "-u"
 			# shift will remove the first arguement "-u"
 			set -- ${@:1:1} "-u" ${@:3}
@@ -107,7 +107,7 @@ while [ $# -gt 0 ]; do
 		else
 			error "imgcat: $2: No such file or url"
 			exit 2
-		fi	
+		fi
 		;;
     -*)
         error "Unknown option flag: $1"
@@ -118,7 +118,7 @@ while [ $# -gt 0 ]; do
         if [ -r "$1" ] ; then
             has_stdin=f
             print_image "$1" 1 "$(base64 < "$1")" "$print_filename"
-		else	
+        else
             error "imgcat: $1: No such file or directory"
             exit 2
         fi

--- a/source/utilities/imgcat
+++ b/source/utilities/imgcat
@@ -62,21 +62,6 @@ function show_help() {
     echo "   or: cat filename | imgcat" 1>& 2
 }
 
-# create image directory under the directory of imgcat
-function img_folder() {
-	dir_name="$(echo ~)/.iterm2/image_collection"
-	if [ ! -d dir_name ]; then
-	    mkdir -p $dir_name
-	fi
-}
-
-# create a list to check if the picture has been downloaded
-function make_list() {
-	if [ ! -f $dir_name/list.txt ]; then
-		touch $dir_name/list.txt
-	fi
-}
-
 ## Main
 
 if [ -t 0 ]; then
@@ -93,6 +78,7 @@ fi
 
 # Look for command line flags.
 while [ $# -gt 0 ]; do
+
     case "$1" in
     -h|--h|--help)
         show_help
@@ -101,6 +87,29 @@ while [ $# -gt 0 ]; do
     -p|--p|--print)
         print_filename=1
         ;;
+	-u|--u|--url)
+        if curl --output /dev/null --silent --head --fail "$2"; then # check if the url is downloadable
+			# create a file with unique file name
+			file=$(mktemp -t curlimg) || { echo "Failed creating file"; return; }
+			# download file and save it into the unique file name just created
+    		curl -s "$2" > $file || { echo "Failed to curl file"; return; }
+			# reset argument of url to the corresponding unique file
+            has_stdin=f
+            print_image "$file" 1 "$(base64 < "$file")" "$print_filename"
+			# delete the downloaded file
+			rm $file
+			# only modify second argument in order to keep running option "-u"
+			# shift will remove the first arguement "-u"
+			set -- ${@:1:1} "-u" ${@:3}
+			# every url has been done, so exit
+			if [ "$#" -eq 2 ]; then
+				exit
+			fi
+		else
+			error "imgcat: $2: No such file or url"
+			exit 2
+		fi	
+		;;
     -*)
         error "Unknown option flag: $1"
         show_help
@@ -108,28 +117,6 @@ while [ $# -gt 0 ]; do
       ;;
     *)
         if [ -r "$1" ] ; then
-            has_stdin=f
-            print_image "$1" 1 "$(base64 < "$1")" "$print_filename"
-        elif curl --output /dev/null --silent --head --fail "$1"; then # check if the url is downloadable
-			img_folder
-			make_list
-			# check if already downloaded from the url
-			if grep -q $1 $dir_name/list.txt; then 
-				# get file name from the list
-				md5_name=$(echo "$(grep $1 $dir_name/list.txt)" | sed 's/.* \([0-9a-f]\)/\1/')
-			else
-				# download file with temporal name called tmp
-				curl $1 -o "$dir_name/tmp" > /dev/null 2>&1
-
-				# rename tmp to its md5 value
-				md5_name=$(echo "$(md5 $dir_name/tmp)" | sed 's/MD5 (.*) = \([0-9a-f]\)/\1/')
-				mv "$dir_name/tmp" "$dir_name/$md5_name"
-
-				# add new download file into the list
-				echo "$1 $md5_name" >> $dir_name/list.txt
-			fi
-			# reset argument of url to the corresponding md5_name
-			set -- "$dir_name/$md5_name"
             has_stdin=f
             print_image "$1" 1 "$(base64 < "$1")" "$print_filename"
 		else	

--- a/source/utilities/imgcat
+++ b/source/utilities/imgcat
@@ -24,7 +24,7 @@ function print_st() {
 #   filename: Filename to convey to client
 #   inline: 0 or 1
 #   base64contents: Base64-encoded contents
-#   print_filename: If non-empty, print the filename
+#   print_filename: If non-empty, print the filename 
 #                   before outputting the image
 function print_image() {
     print_osc
@@ -86,29 +86,15 @@ while [ $# -gt 0 ]; do
     -p|--p|--print)
         print_filename=1
         ;;
-	-u|--u|--url)
-        if curl --output /dev/null --silent --head --fail "$2"; then # check if the url is downloadable
-			# create a file with unique file name
-			file=$(mktemp -t curlimg) || { echo "mktemp failed for url $2"; exit 1; }
-			# download file and save it into the unique file name just created
-    		curl -s "$2" > $file || { echo "curl failed for url $2"; exit 1; }
-			# reset argument of url to the corresponding unique file
-            has_stdin=f
-            print_image "$file" 1 "$(base64 < "$file")" "$print_filename"
-			# delete the downloaded file
-			rm "$file"
-			# only modify second argument in order to keep running option "-u"
-			# shift will remove the first arguement "-u"
-			set -- ${@:1:1} "-u" ${@:3}
-			# every url has been done, so exit
-			if [ "$#" -eq 2 ]; then
-				exit
-			fi
-		else
-			error "imgcat: $2: No such file or url"
-			exit 2
-		fi
-		;;
+    -u|--u|--url)
+        encoded_image=$(curl -s "$2" | base64) || (error "No such file or url $2"; exit 2)
+        has_stdin=f
+        print_image "$file" 1 "$encoded_image" "$print_filename"
+        set -- ${@:1:1} "-u" ${@:3}
+        if [ "$#" -eq 2 ]; then
+            exit
+        fi
+        ;;
     -*)
         error "Unknown option flag: $1"
         show_help
@@ -118,7 +104,7 @@ while [ $# -gt 0 ]; do
         if [ -r "$1" ] ; then
             has_stdin=f
             print_image "$1" 1 "$(base64 < "$1")" "$print_filename"
-        else
+        else    
             error "imgcat: $1: No such file or directory"
             exit 2
         fi

--- a/source/utilities/imgcat
+++ b/source/utilities/imgcat
@@ -78,7 +78,6 @@ fi
 
 # Look for command line flags.
 while [ $# -gt 0 ]; do
-
     case "$1" in
     -h|--h|--help)
         show_help
@@ -132,6 +131,5 @@ done
 if [ $has_stdin = t ]; then
     print_image "" 1 "$(cat | base64)" ""
 fi
-
 
 exit 0


### PR DESCRIPTION
curl
I utilize curl to check if the file can be downloaded from the provided url.
If yes, downloads it in the path "~/.iterm2/image_collection" and create a list.txt.
list.txt file is used to check if the user has downloads file from the url.
Users can save time if they have already downloaded the file from the url.

md5
I use the value of each file's md5 as its name.
If I download a new file whose md5 value is identical to the file user downloaded, in practical, the new file is the same file.
Therefore, we only need to store one.