### PR TITLE
Improve stty handling in it2check and it2getvar

### DIFF
--- a/source/utilities/it2check
+++ b/source/utilities/it2check
@@ -7,17 +7,6 @@ if [ ! -t 1 ] ; then
   exit 1
 fi
 
-# Save the tty's state.
-saved_stty=$(stty -g)
-
-# Trap ^C to fix the tty.
-trap ctrl_c INT
-
-function ctrl_c() {
-  stty "$saved_stty"
-  exit 1
-}
-
 # Read some bytes from stdin. Pass the number of bytes to read as the first argument.
 function read_bytes()
 {
@@ -45,6 +34,13 @@ function terminal {
 # Extract the version number from DSR 1337
 function version {
   echo -n "$1" | sed -e 's/.* //'
+}
+
+trap clean_up EXIT
+_STTY=$(stty -g)      ## Save current terminal setup
+
+function clean_up() {
+  stty "$_STTY"            ## Restore terminal settings
 }
 
 # Enter raw mode and turn off echo so the terminal and I can chat quietly.
@@ -76,9 +72,6 @@ else
   # Terminal didn't respond to the DSR 1337. The response we read is from DSR 5.
   version_string=""
 fi
-
-# Restore the terminal to cooked mode.
-stty "$saved_stty"
 
 # Extract the terminal name and version number from the response.
 version=$(version "${version_string}")

--- a/source/utilities/it2getvar
+++ b/source/utilities/it2getvar
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-function ctrl_c() {
-  stty "$saved_stty"
-  exit 1
-}
-
 # tmux requires unrecognized OSC sequences to be wrapped with DCS tmux;
 # <sequence> ST, and for all ESCs in <sequence> to be replaced with ESC ESC. It
 # only accepts ESC backslash for ST.
@@ -64,11 +59,12 @@ then
   exit 1
 fi
 
-# Save the tty's state.
-saved_stty=$(stty -g)
+trap clean_up EXIT
+_STTY=$(stty -g)      ## Save current terminal setup
 
-# Trap ^C to fix the tty.
-trap ctrl_c INT
+function clean_up() {
+  stty "$_STTY"            ## Restore terminal settings
+}
 
 # Enter raw mode and turn off echo so the terminal and I can chat quietly.
 stty -echo -icanon raw


### PR DESCRIPTION
This copies the more robust handling of stty from it2ul to it2check and it2getvar. Trapping the stty restoration on EXIT means we're covered in all situations that might cause the script to exit early, not just the user hitting Ctrl+C, and means we don't need to remember to do it in the script's happy path. Accordingly, this fixes an issue in which it2getvar did not restore the stty settings if execution completed without issue.