### PR TITLE
 Correct ssh config path in docs

### DIFF
--- a/source/_includes/3.0/documentation-shell-integration.md
+++ b/source/_includes/3.0/documentation-shell-integration.md
@@ -215,7 +215,7 @@ Settings pulled from ssh_config override the hostname and user name provided by 
 The following files are parsed as ssh_config files, in order of priority:
 
   * ~/Library/Application Support/iTerm/ssh_config
-  * ~/.ssh/ssh_config
+  * ~/.ssh/config
   * /etc/ssh_config
 
 The scp code is relatively new. If you are in a high-security environment, please keep this in mind.

--- a/source/_includes/documentation-shell-integration.md
+++ b/source/_includes/documentation-shell-integration.md
@@ -278,7 +278,7 @@ Settings pulled from ssh_config override the hostname and user name provided by 
 The following files are parsed as ssh_config files, in order of priority:
 
   * ~/Library/Application Support/iTerm/ssh_config
-  * ~/.ssh/ssh_config
+  * ~/.ssh/config
   * /etc/ssh_config
 
 The scp code is relatively new. If you are in a high-security environment, please keep this in mind.


### PR DESCRIPTION
Match to the [actual behavior](
https://github.com/gnachman/iTerm2/blob/f8a5930b5c47fa6420f423fcb33320029abdcd5b/sources/SCPFile.m#L194-L196), which is correct.