### PR TITLE
two fixes for imgcat

### DIFF
--- a/source/utilities/imgcat
+++ b/source/utilities/imgcat
@@ -226,7 +226,7 @@ done
 
 # Read and print stdin
 if [ $has_stdin = t ]; then
-    print_image "" 1 "$(cat | b64)" ""
+    print_image "stdin" 1 "$(cat | b64)" ""
 fi
 
 exit 0

--- a/source/utilities/imgcat
+++ b/source/utilities/imgcat
@@ -49,6 +49,18 @@ function read_ack() {
   echo -n ${body:1}
 }
 
+b64() {
+    printf 'junk' | base64 -w0 >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        # gnu
+        cat | base64 -w0
+        printf '\n'
+    else
+        # bsd
+        cat | base64
+    fi
+}
+
 # print_image filename inline base64contents print_filename
 #   filename: Filename to convey to client
 #   inline: 0 or 1
@@ -72,7 +84,7 @@ function print_image() {
 
 function print_payload() {
     if [[ -n "$1" ]]; then
-      printf 'name='`printf "%s" "$1" | base64`";"
+      printf 'name='`printf "%s" "$1" | b64`";"
     fi
 
     VERSION=$(base64 --version 2>&1)
@@ -186,7 +198,7 @@ while [ $# -gt 0 ]; do
         ;;
     -u|--u|--url)
         check_dependency curl
-        encoded_image=$(curl -s "$2" | base64) || (error "No such file or url $2"; exit 2)
+        encoded_image=$(curl -s "$2" | b64) || (error "No such file or url $2"; exit 2)
         has_stdin=f
         print_image "$2" 1 "$encoded_image" "$print_filename"
         set -- ${@:1:1} "-u" ${@:3}
@@ -202,7 +214,7 @@ while [ $# -gt 0 ]; do
     *)
         if [ -r "$1" ] ; then
             has_stdin=f
-            print_image "$1" 1 "$(base64 < "$1")" "$print_filename"
+            print_image "$1" 1 "$(b64 < "$1")" "$print_filename"
         else
             error "imgcat: $1: No such file or directory"
             exit 2
@@ -214,7 +226,7 @@ done
 
 # Read and print stdin
 if [ $has_stdin = t ]; then
-    print_image "" 1 "$(cat | base64)" ""
+    print_image "" 1 "$(cat | b64)" ""
 fi
 
 exit 0


### PR DESCRIPTION
6da26d5 fixes broken images under GNU `base64`, e.g. in a clean `ubuntu` Docker image you get:

![image](https://user-images.githubusercontent.com/1566363/50668095-dd4c5880-0f71-11e9-99f5-cc1f2d74c50b.png)

de7648d fixes `cat image.png | imgcat` popping up a macOS notification about an image named "1" being downloaded, instead of printing the image in iTerm:

![image](https://user-images.githubusercontent.com/1566363/50668185-63689f00-0f72-11e9-81d5-5a2d5064f146.png)