### PR TITLE
it2git: short-circuit if we are not in a git repo.

### DIFF
--- a/source/utilities/it2git
+++ b/source/utilities/it2git
@@ -93,6 +93,14 @@ git_poll () {
     iterm2_set_user_var gitPullCount "$PULL_COUNT"
 }
 
-git_poll "$PWD"
+"$GIT_BINARY" rev-parse --git-dir 2>/dev/null >/dev/null
+if (($?)); then
+    iterm2_set_user_var gitBranch ""
+    iterm2_set_user_var gitDirty ""
+    iterm2_set_user_var gitPushCount ""
+    iterm2_set_user_var gitPullCount ""
+else
+    git_poll "$PWD"
+fi
 
 


### PR DESCRIPTION
Check to see if PWD is in a git repo before running
subsequent commands that are only useful within a git
repo.