### PR TITLE
Set iterator scope to local in shell integration

### DIFF
--- a/source/shell_integration/bash
+++ b/source/shell_integration/bash
@@ -129,6 +129,7 @@ __bp_inside_preexec=0
 # Fails if any of the given variables are readonly
 # Reference https://stackoverflow.com/a/4441178
 __bp_require_not_readonly() {
+  local var
   for var; do
     if ! ( unset "$var" 2> /dev/null ); then
       echo "iTerm2 Shell Integration: bash-preexec requires write access to ${var}" >&2


### PR DESCRIPTION
Bash doesn't automatically scope the iterator in a for loop.
Before this change, sourcing this script results in global "$var=HISTTIMEFORMAT"