### PR TITLE
Improve imgcat formatting

### DIFF
--- a/source/utilities/imgcat
+++ b/source/utilities/imgcat
@@ -5,7 +5,7 @@
 # only accepts ESC backslash for ST. We use TERM instead of TMUX because TERM
 # gets passed through ssh.
 function print_osc() {
-    if [[ $TERM == screen* ]] ; then
+    if [[ $TERM == screen* ]]; then
         printf "\033Ptmux;\033\033]"
     else
         printf "\033]"
@@ -14,7 +14,7 @@ function print_osc() {
 
 # More of the tmux workaround described above.
 function print_st() {
-    if [[ $TERM == screen* ]] ; then
+    if [[ $TERM == screen* ]]; then
         printf "\a\033\\"
     else
         printf "\a"
@@ -23,13 +23,14 @@ function print_st() {
 
 function load_version() {
     if [ -z ${IMGCAT_BASE64_VERSION+x} ]; then
-        export IMGCAT_BASE64_VERSION=$(base64 --version 2>&1)
+        IMGCAT_BASE64_VERSION=$(base64 --version 2>&1)
+        export IMGCAT_BASE64_VERSION
     fi
 }
 
 function b64_encode() {
     load_version
-    if [[ "$IMGCAT_BASE64_VERSION" =~ GNU ]]; then
+    if [[ $IMGCAT_BASE64_VERSION =~ GNU ]]; then
         # Disable line wrap
         base64 -w0
     else
@@ -39,12 +40,12 @@ function b64_encode() {
 
 function b64_decode() {
     load_version
-    if [[ "$IMGCAT_BASE64_VERSION" =~ fourmilab ]]; then
-      BASE64ARG=-d
-    elif [[ "$IMGCAT_BASE64_VERSION" =~ GNU ]]; then
-      BASE64ARG=-di
+    if [[ $IMGCAT_BASE64_VERSION =~ fourmilab ]]; then
+        BASE64ARG=-d
+    elif [[ $IMGCAT_BASE64_VERSION =~ GNU ]]; then
+        BASE64ARG=-di
     else
-      BASE64ARG=-D
+        BASE64ARG=-D
     fi
     base64 $BASE64ARG
 }
@@ -53,23 +54,23 @@ function b64_decode() {
 #   filename: Filename to convey to client
 #   inline: 0 or 1
 #   base64contents: Base64-encoded contents
-#   print_filename: If non-empty, print the filename 
+#   print_filename: If non-empty, print the filename
 #                   before outputting the image
 function print_image() {
     print_osc
     printf '1337;File='
-    if [[ -n "$1" ]]; then
-      printf 'name='`printf "%s" "$1" | b64_encode`";"
+    if [[ -n $1 ]]; then
+        printf "name=%s;" "$(printf "%s" "$1" | b64_encode)"
     fi
 
     printf "%s" "$3" | b64_decode | wc -c | awk '{printf "size=%d",$1}'
-    printf ";inline=$2"
+    printf ";inline=%s" "$2"
     printf ":"
     printf "%s" "$3"
     print_st
     printf '\n'
-    if [[ -n "$4" ]]; then
-      echo $1
+    if [[ -n $4 ]]; then
+        echo "$1"
     fi
 }
 
@@ -78,15 +79,15 @@ function error() {
 }
 
 function show_help() {
-    echo "Usage: imgcat [-p] filename ..." 1>& 2
-    echo "   or: cat filename | imgcat" 1>& 2
+    echo "Usage: imgcat [-p] filename ..." 1>&2
+    echo "   or: cat filename | imgcat" 1>&2
 }
 
 function check_dependency() {
-  if ! (builtin command -V "$1" > /dev/null 2>& 1); then
-    echo "imgcat: missing dependency: can't find $1" 1>& 2
-    exit 1
-  fi
+    if ! (builtin command -V "$1" >/dev/null 2>&1); then
+        echo "imgcat: missing dependency: can't find $1" 1>&2
+        exit 1
+    fi
 }
 
 ## Main
@@ -98,7 +99,7 @@ else
 fi
 
 # Show help if no arguments and no stdin.
-if [ $has_stdin = f -a $# -eq 0 ]; then
+if [ $has_stdin = f ] && [ $# -eq 0 ]; then
     show_help
     exit
 fi
@@ -110,19 +111,22 @@ check_dependency wc
 # Look for command line flags.
 while [ $# -gt 0 ]; do
     case "$1" in
-    -h|--h|--help)
+    -h | --h | --help)
         show_help
         exit
         ;;
-    -p|--p|--print)
+    -p | --p | --print)
         print_filename=1
         ;;
-    -u|--u|--url)
+    -u | --u | --url)
         check_dependency curl
-        encoded_image=$(curl -s "$2" | b64_encode) || (error "No such file or url $2"; exit 2)
+        encoded_image=$(curl -s "$2" | b64_encode) || (
+            error "No such file or url $2"
+            exit 2
+        )
         has_stdin=f
         print_image "$2" 1 "$encoded_image" "$print_filename"
-        set -- ${@:1:1} "-u" ${@:3}
+        set -- "${@:1:1}" "-u" "${@:3}"
         if [ "$#" -eq 2 ]; then
             exit
         fi
@@ -131,11 +135,11 @@ while [ $# -gt 0 ]; do
         error "Unknown option flag: $1"
         show_help
         exit 1
-      ;;
+        ;;
     *)
-        if [ -r "$1" ] ; then
+        if [ -r "$1" ]; then
             has_stdin=f
-            print_image "$1" 1 "$(b64_encode < "$1")" "$print_filename"
+            print_image "$1" 1 "$(b64_encode <"$1")" "$print_filename"
         else
             error "imgcat: $1: No such file or directory"
             exit 2


### PR DESCRIPTION
Improved formatting with `shfmt -i=4 -s` https://github.com/mvdan/sh#shfmt to ensure that it passes shellcheck https://github.com/koalaman/shellcheck#shellcheck---a-shell-script-static-analysis-tool.