### PR TITLE
Fix missing prompt when not using vi mode

### DIFF
--- a/source/shell_integration/fish
+++ b/source/shell_integration/fish
@@ -98,12 +98,13 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ 
    else
      # fish_mode_prompt is empty or unset.
      function fish_prompt --description 'Write out the mode prompt; do not replace this. Instead, change fish_mode_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_mode_prompt instead.'
+        iterm2_common_prompt
+
         # Remove the trailing newline from the original prompt. This is done
         # using the string builtin from fish, but to make sure any escape codes
         # are correctly interpreted, use %b for printf.
         printf "%b" (string join "\n" (iterm2_fish_prompt))
 
-        iterm2_common_prompt
         iterm2_prompt_end
      end
    end

--- a/source/shell_integration/fish
+++ b/source/shell_integration/fish
@@ -98,6 +98,11 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ 
    else
      # fish_mode_prompt is empty or unset.
      function fish_prompt --description 'Write out the mode prompt; do not replace this. Instead, change fish_mode_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_mode_prompt instead.'
+        # Remove the trailing newline from the original prompt. This is done
+        # using the string builtin from fish, but to make sure any escape codes
+        # are correctly interpreted, use %b for printf.
+        printf "%b" (string join "\n" (iterm2_fish_prompt))
+
         iterm2_common_prompt
         iterm2_prompt_end
      end


### PR DESCRIPTION
The prompt disappeared today when I updated the iTerm integration. The non-vi mode `fish_prompt` function wasn't calling the user defined `fish_prompt`, but a small copy paste later and it starts working again.