### PR TITLE
[fish shell integration] refactor `fish_mode_prompt` check

### DIFF
--- a/source/shell_integration/fish
+++ b/source/shell_integration/fish
@@ -39,12 +39,12 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ 
   # Gives a variable accessible in a badge by \(user.currentDirectory)
   # Calls to this go in iterm2_print_user_vars.
   function iterm2_set_user_var
-    printf "\033]1337;SetUserVar=%s=%s\007" "$argv[1]" (printf "%s" "$argv[2]" | base64 | tr -d "\n")
+    printf "\033]1337;SetUserVar=%s=%s\007" $argv[1] (printf "%s" $argv[2] | base64 | tr -d "\n")
   end
 
   function iterm2_write_remotehost_currentdir_uservars
     if not set -q -g iterm2_hostname
-      printf "\033]1337;RemoteHost=%s@%s\007\033]1337;CurrentDir=%s\007" $USER (hostname -f 2> /dev/null) $PWD
+      printf "\033]1337;RemoteHost=%s@%s\007\033]1337;CurrentDir=%s\007" $USER (hostname -f 2>/dev/null) $PWD
     else
       printf "\033]1337;RemoteHost=%s@%s\007\033]1337;CurrentDir=%s\007" $USER $iterm2_hostname $PWD
     end
@@ -54,60 +54,55 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ 
     if functions -q -- iterm2_print_user_vars
       iterm2_print_user_vars
     end
-
   end
 
   functions -c fish_prompt iterm2_fish_prompt
 
-   function iterm2_common_prompt
-        set -l last_status $status
+  function iterm2_common_prompt
+    set -l last_status $status
 
-        iterm2_status $last_status
-        iterm2_write_remotehost_currentdir_uservars
-        if not functions iterm2_fish_prompt | grep iterm2_prompt_mark > /dev/null
-            iterm2_prompt_mark
-        end
-        sh -c "exit $last_status"
-   end
+    iterm2_status $last_status
+    iterm2_write_remotehost_currentdir_uservars
+    if not functions iterm2_fish_prompt | grep -q iterm2_prompt_mark
+      iterm2_prompt_mark
+    end
+    sh -c "exit $last_status"
+  end
 
-  function iterm2_has_fish_mode_prompt -d "Returns true iff fish_mode_prompt is defined and non-empty"
-     if test (functions fish_mode_prompt | grep -vE '^ *(#|function |end$|$)' | wc -l) = 0
-       echo -n false
-     else
-       echo -n true
-     end
-   end
+  function iterm2_check_function -d "Check if function is defined and non-empty"
+    test (functions $argv[1] | grep -cvE '^ *(#|function |end$|$)') != 0
+  end
 
-   if test (iterm2_has_fish_mode_prompt) = true
-     # Only override fish_mode_prompt if it is non-empty. This works around a problem created by a
-     # workaround in starship: https://github.com/starship/starship/issues/1283
-     functions -c fish_mode_prompt iterm2_fish_mode_prompt
-     function fish_mode_prompt --description 'Write out the mode prompt; do not replace this. Instead, change fish_mode_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_mode_prompt instead.'
-        iterm2_common_prompt
-        iterm2_fish_mode_prompt
-     end
+  if iterm2_check_function fish_mode_prompt
+    # Only override fish_mode_prompt if it is non-empty. This works around a problem created by a
+    # workaround in starship: https://github.com/starship/starship/issues/1283
+    functions -c fish_mode_prompt iterm2_fish_mode_prompt
+    function fish_mode_prompt --description 'Write out the mode prompt; do not replace this. Instead, change fish_mode_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_mode_prompt instead.'
+      iterm2_common_prompt
+      iterm2_fish_mode_prompt
+    end
 
-     function fish_prompt --description 'Write out the prompt; do not replace this. Instead, change fish_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_prompt instead.'
-        # Remove the trailing newline from the original prompt. This is done
-        # using the string builtin from fish, but to make sure any escape codes
-        # are correctly interpreted, use %b for printf.
-        printf "%b" (string join "\n" (iterm2_fish_prompt))
+    function fish_prompt --description 'Write out the prompt; do not replace this. Instead, change fish_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_prompt instead.'
+      # Remove the trailing newline from the original prompt. This is done
+      # using the string builtin from fish, but to make sure any escape codes
+      # are correctly interpreted, use %b for printf.
+      printf "%b" (string join "\n" (iterm2_fish_prompt))
 
-        iterm2_prompt_end
-     end
-   else
-     # fish_mode_prompt is empty or unset.
-     function fish_prompt --description 'Write out the mode prompt; do not replace this. Instead, change fish_mode_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_mode_prompt instead.'
-        iterm2_common_prompt
+      iterm2_prompt_end
+    end
+  else
+    # fish_mode_prompt is empty or unset.
+    function fish_prompt --description 'Write out the mode prompt; do not replace this. Instead, change fish_mode_prompt before sourcing .iterm2_shell_integration.fish, or modify iterm2_fish_mode_prompt instead.'
+      iterm2_common_prompt
 
-        # Remove the trailing newline from the original prompt. This is done
-        # using the string builtin from fish, but to make sure any escape codes
-        # are correctly interpreted, use %b for printf.
-        printf "%b" (string join "\n" (iterm2_fish_prompt))
+      # Remove the trailing newline from the original prompt. This is done
+      # using the string builtin from fish, but to make sure any escape codes
+      # are correctly interpreted, use %b for printf.
+      printf "%b" (string join "\n" (iterm2_fish_prompt))
 
-        iterm2_prompt_end
-     end
-   end
+      iterm2_prompt_end
+    end
+  end
 
   # If hostname -f is slow for you, set iterm2_hostname before sourcing this script
   if not set -q -g iterm2_hostname
@@ -123,5 +118,5 @@ if begin; status --is-interactive; and not functions -q -- iterm2_status; and [ 
   end
 
   iterm2_write_remotehost_currentdir_uservars
-  printf "\033]1337;ShellIntegrationVersion=15;shell=fish\007"
+  printf "\033]1337;ShellIntegrationVersion=16;shell=fish\007"
 end


### PR DESCRIPTION
Introduce generic `iterm2_check_function` helper.
Fix inconsistent indentation and remove unnecessary quotes.