### PR TITLE
AboutWindow bug fix

### DIFF
--- a/source/patrons.txt
+++ b/source/patrons.txt
@@ -90,7 +90,7 @@ Oleg Evdokimov
 Oleksandr Tymoshenko
 Olga Akhrameeva
 Oliver B. Fischer
-Ondřej Surý
+Ondrej Sury
 Paul Lind
 Peter Steinberger (PSPDFKit)
 Philip Borenstein

--- a/source/patrons.txt
+++ b/source/patrons.txt
@@ -90,7 +90,7 @@ Oleg Evdokimov
 Oleksandr Tymoshenko
 Olga Akhrameeva
 Oliver B. Fischer
-Ondrej Sury
+Ondřej Surý
 Paul Lind
 Peter Steinberger (PSPDFKit)
 Philip Borenstein

--- a/source/patrons.txt
+++ b/source/patrons.txt
@@ -43,7 +43,7 @@ David Cuthbert
 David Mankin
 Ean Price
 Elijah Miller
-Emily St＊
+Emily St
 Eoin Woods
 Federico Marzocchi
 Frank Fejes

--- a/source/patrons.txt
+++ b/source/patrons.txt
@@ -43,7 +43,7 @@ David Cuthbert
 David Mankin
 Ean Price
 Elijah Miller
-Emily St
+Emily St*
 Eoin Woods
 Federico Marzocchi
 Frank Fejes


### PR DESCRIPTION
There is a cosmetic issue in the `iTermAboutWindow` where line spacing, the font, and/or other styling gets thrown off by unique characters in the patrons list, starting with `＊` in `Emily St＊` and ending with `ř` in `Ondřej Surý` :

![Screenshot](https://content.screencast.com/users/ConnorConnorF/folders/Snagit/media/9a8d3c16-da1d-4509-9ded-6fb7c2773b09/2022-02-07_11-39-50.png)

This string appears to be fetched etc from the static file `patrons.txt` on `iterm2-website`. 

This pull request simply removes and/or updates the unique characters. Submitting as a draft because I have been unable[1] to successfully build iTerm2 locally with Xcode to test this change by linking to a local edited version of `patrons.txt`.

No doubt there is more than one way to resolve this. If I could run locally, would be happy to tinker with `iTermAboutWindowController.m` to come up with something more robust and future-proof (plus work on some other open issues too).

But until then, all signs seem to point to these edits being a quick and easy solution.

---

More about build errors:

[1]: Followed steps at https://gitlab.com/gnachman/iterm2/-/wikis/HowToBuild (and stackexchange posts galore) but am stuck on the following build errors:

![Errors](https://content.screencast.com/users/ConnorConnorF/folders/Snagit/media/5d1e29f2-d3c9-4d9a-84cc-62c68d91bc1b/2022-02-07_13-57-45.png)

Running:
- OS version: macOS 12.1
- Xcode version: 13.2.1

There may be something very basic that I'm missing due to being new with Xcode and Swift. Or could be that the HowToBuild steps (last updated 11 months ago) may no longer be accurate. It would appear I am not alone on this build issue: https://gitlab.com/gnachman/iterm2/-/issues/9993#note_834296482 and it would also appear that maybe this won't be an issue in the future depending how things go here: https://github.com/gnachman/iTerm2/pull/460