### PR TITLE
Fixed a typo: Tolbelt -> Toolbelt

### DIFF
--- a/source/_includes/3.0/documentation-menu-items.md
+++ b/source/_includes/3.0/documentation-menu-items.md
@@ -167,7 +167,7 @@ If you have scripts located in `$HOME/Library/Application Support/iTerm/Scripts`
 #### Toolbelt > Set Default Width
 Saves the current window's toolbelt width as the default width for new windows' toolbelts.
 
-#### Tolbelt > Captured Output
+#### Toolbelt > Captured Output
 This toggles the visibilty of the Captured Output tool. It shows captured output located with the Capture Output trigger. See <a href="captured_output.html">Captured Output</a> for more information.
 
 #### Toolbelt > Command History

--- a/source/_includes/3.1/documentation-toolbelt-menu.md
+++ b/source/_includes/3.1/documentation-toolbelt-menu.md
@@ -1,7 +1,7 @@
 #### Toolbelt > Set Default Width
 Saves the current window's toolbelt width as the default width for new windows' toolbelts.
 
-#### Tolbelt > Captured Output
+#### Toolbelt > Captured Output
 This toggles the visibilty of the Captured Output tool. It shows captured output located with the Capture Output trigger. See <a href="captured_output.html">Captured Output</a> for more information.
 
 #### Toolbelt > Command History

--- a/source/_includes/3.2/documentation-toolbelt-menu.md
+++ b/source/_includes/3.2/documentation-toolbelt-menu.md
@@ -1,7 +1,7 @@
 #### Toolbelt > Set Default Width
 Saves the current window's toolbelt width as the default width for new windows' toolbelts.
 
-#### Tolbelt > Captured Output
+#### Toolbelt > Captured Output
 This toggles the visibilty of the Captured Output tool. It shows captured output located with the Capture Output trigger. See <a href="captured_output.html">Captured Output</a> for more information.
 
 #### Toolbelt > Command History

--- a/source/_includes/3.3/documentation-toolbelt-menu.md
+++ b/source/_includes/3.3/documentation-toolbelt-menu.md
@@ -4,7 +4,7 @@ Saves the current window's toolbelt width as the default width for new windows' 
 #### Toolbelt > Actions
 This toggles the visibility of the Actions tools. It has a list of user-defined actions (for example, send a canned string of text). The tool provides an interface for editing the actions as well as invoking them.
 
-#### Tolbelt > Captured Output
+#### Toolbelt > Captured Output
 This toggles the visibilty of the Captured Output tool. It shows captured output located with the Capture Output trigger. See <a href="captured_output.html">Captured Output</a> for more information.
 
 #### Toolbelt > Command History

--- a/source/_includes/3.4/documentation-toolbelt-menu.md
+++ b/source/_includes/3.4/documentation-toolbelt-menu.md
@@ -4,7 +4,7 @@ Saves the current window's toolbelt width as the default width for new windows' 
 #### Toolbelt > Actions
 This toggles the visibility of the Actions tools. It has a list of user-defined actions (for example, send a canned string of text). The tool provides an interface for editing the actions as well as invoking them.
 
-#### Tolbelt > Captured Output
+#### Toolbelt > Captured Output
 This toggles the visibilty of the Captured Output tool. It shows captured output located with the Capture Output trigger. See <a href="captured_output.html">Captured Output</a> for more information.
 
 #### Toolbelt > Command History

--- a/source/_includes/3.5/documentation-toolbelt-menu.md
+++ b/source/_includes/3.5/documentation-toolbelt-menu.md
@@ -1,7 +1,7 @@
 #### Toolbelt > Set Default Width
 Saves the current window's toolbelt width as the default width for new windows' toolbelts.
 
-#### Tolbelt > Captured Output
+#### Toolbelt > Captured Output
 This toggles the visibilty of the Captured Output tool. It shows captured output located with the Capture Output trigger. See <a href="captured_output.html">Captured Output</a> for more information.
 
 #### Toolbelt > Command History

--- a/source/_includes/documentation-toolbelt-menu.md
+++ b/source/_includes/documentation-toolbelt-menu.md
@@ -1,7 +1,7 @@
 #### Toolbelt > Set Default Width
 Saves the current window's toolbelt width as the default width for new windows' toolbelts.
 
-#### Tolbelt > Captured Output
+#### Toolbelt > Captured Output
 This toggles the visibilty of the Captured Output tool. It shows captured output located with the Capture Output trigger. See <a href="captured_output.html">Captured Output</a> for more information.
 
 #### Toolbelt > Command History


### PR DESCRIPTION
Found a typo in the documentation, corrected it in the `.md` files. No other changes.