### PR TITLE
Update index.md to note that macOS 12.4+ is needed now

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -5,7 +5,7 @@ active-state: index
 ---
 
 #### What is iTerm2?
-iTerm2 is a replacement for Terminal and the successor to iTerm. It works on Macs with macOS 10.14 or newer. iTerm2 brings the terminal into the modern age with features you never knew you always wanted.
+iTerm2 is a replacement for Terminal and the successor to iTerm. It works on Macs with macOS 12.4 or newer. iTerm2 brings the terminal into the modern age with features you never knew you always wanted.
 
 #### Why Do I Want It?
 Check out the impressive <a href="features.html">features and screenshots</a>. If you spend a lot of time in a terminal, then you'll appreciate all the little things that add up to a lot. It is free software and you can find the source code on <a href="https://github.com/gnachman/iTerm2">GitHub</a>.


### PR DESCRIPTION
Just updating the minimum version requirement note to 12.4, to match current versions of iTerm2.